### PR TITLE
Fix typo

### DIFF
--- a/src/feature/full_model.py
+++ b/src/feature/full_model.py
@@ -16,7 +16,7 @@ class FullModelFeatureExtractor(SeversonFeatureExtractor):
             'Slope of linear fit to the capacity curve',
             'Intercept of linear fit to the capacity curve',
             'Early discharge capacity',
-            'Averange early charge time',
+            'Average early charge time',
             'Integral of temperature over time',
             'Minimum internal resistance',
             'Internal resistance change'

--- a/src/feature/severson.py
+++ b/src/feature/severson.py
@@ -150,7 +150,7 @@ class SeversonFeatureExtractor(BaseFeatureExtractor):
             return model.intercept_
 
         # Other features
-        if feature == 'Averange early charge time':
+        if feature == 'Average early charge time':
             charge_time = []
             for cycle in range(4):
                 cycle_data = cell_data.cycle_data[cycle]


### PR DESCRIPTION
Fixed a spelling error in the feature name 'Averange early charge time' by replacing it with 'Average early charge time'.