### PR TITLE
fix bug in preprocessing HNEI dataset

### DIFF
--- a/batteryml/preprocess/preprocess_HNEI.py
+++ b/batteryml/preprocess/preprocess_HNEI.py
@@ -50,7 +50,7 @@ class HNEIPreprocessor(BasePreprocessor):
 
 
 def organize_cell(timeseries_df, name, C):
-    timeseries_df = timeseries_df.sort_values('Cycle_Index')
+    timeseries_df = timeseries_df.sort_values('Test_Time (s)')
     cycle_data = []
     for cycle_index, df in timeseries_df.groupby('Cycle_Index'):
         if cycle_index < 12:  # First 12 cycles are problematic
@@ -116,10 +116,10 @@ def clean_cell(timeseries_df, cycle_data_df, shifts=2, **kwargs):
         cdfs.append(cdf)
     timeseries_df = pd.concat([
         timeseries_df[~timeseries_df.Cycle_Index.isin(cycle_to_exclude)], *tdfs
-    ]).reset_index(drop=True).sort_values('Cycle_Index')
+    ]).reset_index(drop=True).sort_values('Test_Time (s)')
     cycle_data_df = pd.concat([
         cycle_data_df[~cycle_data_df.Cycle_Index.isin(cycle_to_exclude)], *cdfs
-    ]).reset_index(drop=True).sort_values('Cycle_Index')
+    ]).reset_index(drop=True).sort_values('Test_Time (s)')
     return timeseries_df, cycle_data_df
 
 


### PR DESCRIPTION
I identified an issue with the original code that processes HNEI data, where the time series data is incorrectly sorted based on the Cycle_Index. This sorting disrupts the original order of the experimental current-voltage profile, leading to anomalies such as an unrealistic increase and sudden decrease in capacity, which occur in tandem with a decreasing recorded time (as shown in the attached figure).

By instead sorting the time series based on Test_Time (s), this bug is resolved. Additionally, I suspect that similar issues might exist in the preprocessing of other datasets, such as the OX dataset. This bug could potentially affect reported model performances, so it is recommended to further investigate and address this in related preprocessing scripts.

![Sort_error](https://github.com/user-attachments/assets/a09040b1-ecb3-4af3-8d66-ebd04baa20df)
