### PR TITLE
Fix feature transformation error in transformer model

### DIFF
--- a/configs/baselines/nn_models/transformer/hust.yaml
+++ b/configs/baselines/nn_models/transformer/hust.yaml
@@ -17,6 +17,8 @@ feature:
     use_precalculated_qdlin: True
 label:
     name: 'RULLabelAnnotator'
+feature_transformation:
+    name: 'ZScoreDataTransformation'
 label_transformation:
     name: 'SequentialDataTransformation'
     transformations:


### PR DESCRIPTION
Fixes #54

Add `feature_transformation` field to the transformer model configuration file.

* Add `feature_transformation` field to `configs/baselines/nn_models/transformer/hust.yaml`.
* Set `feature_transformation` field to `name: 'ZScoreDataTransformation'`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/microsoft/BatteryML/pull/55?shareId=3fcbd441-7fda-428f-9153-cf25107dfe0f).